### PR TITLE
ec2: try get console log with latest enabled

### DIFF
--- a/avocado_cloud/app/aws/sdk.py
+++ b/avocado_cloud/app/aws/sdk.py
@@ -352,6 +352,11 @@ class EC2VM(VM):
 
     def get_console_log(self):
         try:
+            output = self.__ec2_instance.console_output(Latest=True).get('Output')
+            return True, output
+        except Exception as err:
+            LOG.error("Failed to get console log, try without latest! %s" % err)
+        try:
             output = self.__ec2_instance.console_output().get('Output')
             return True, output
         except Exception as err:


### PR DESCRIPTION
Not all instance types support this option, so continue to get console
log with latest disabled if exception hit.

Signed-off-by: Xiao Liang <xiliang@redhat.com>