### PR TITLE
Add AzureImage class. Create image in gen2 test in Azure cloud-init test

### DIFF
--- a/avocado_cloud/app/azure/sdk.py
+++ b/avocado_cloud/app/azure/sdk.py
@@ -357,6 +357,74 @@ class AzureNicIpConfig(Base):
         return self.show()
 
 
+class AzureImage(Base):
+    basecli = 'az image'
+
+    def __init__(self, params, **kwargs):
+        """
+        :param: name:[REQUIRED]image name
+        :param: source:[REQUIRED]The source(.vhd url) of the image
+        """
+        super(AzureImage, self).__init__(params)
+        size = kwargs.get("size") if "size" in kwargs else params.get(
+            "size", "*/VM/*")
+        self.resource_group = params.get("resource_group",
+                                         "*/vm_sizes/{}/*".format(size))
+        vhd_name = params.get("image", "*/VM/*")
+        storage_account = params.get("storage_account",
+                                     "*/vm_sizes/{}/*".format(size))
+        self.source = "https://{}.blob.core.windows.net/vhds/{}"\
+                      .format(storage_account, vhd_name)
+        timestamp = time.strftime("%m%d%H%M%S", time.localtime())
+        self.generation = kwargs.get("generation", "V1")
+        self.name = kwargs.get("name", "{}-{}-{}".format(vhd_name.replace(".vhd", ''),
+                               self.generation, timestamp))
+        # After it is created, properties below will be set
+        self.id = None
+        self.properties = None
+
+    def create(self):
+        cmd = self.basecli + ' create --name "{}" --resource-group "{}" '\
+            '--source {} --hyper-v-generation {} --os-type linux'.format(
+                self.name, self.resource_group, self.source, self.generation)
+        ret = command(cmd)
+        if len(ret.stdout):
+            info = json.loads(ret.stdout)
+            self.id = info["id"]
+            self.properties = info
+            return True
+
+    def delete(self):
+        cmd = self.basecli + ' delete --name {} --resource-group "{}"'.format(
+                self.name, self.resource_group)
+        command(cmd)
+        return True
+
+    def show(self):
+        cmd = self.basecli + ' show --name {} --resource-group "{}"'.format(
+                self.name, self.resource_group)
+        try:
+            ret = command(cmd)
+        except:
+            return False
+        if len(ret.stdout):
+            info = json.loads(ret.stdout)
+            self.id = info["id"]
+            self.properties = info
+            return True
+
+    def update(self):
+        self.show()
+
+    def list(self):
+        cmd = self.basecli + " list"
+        ret = command(cmd)
+        return json.loads(ret.stdout)
+
+    def exists(self):
+        return self.show()
+
+
 class AzureVM(VM):
     def __init__(self, params, **kwargs):
         super(AzureVM, self).__init__(params)
@@ -413,10 +481,10 @@ class AzureVM(VM):
     def create(self, wait=True):
         cmd = 'az vm create --name "{}" --resource-group "{}" --image "{}" '\
             '--size "{}" --admin-username "{}" --authentication-type "{}" '\
-            '--storage-account "{}" --os-disk-name "{}"'\
+            ' --os-disk-name "{}"'\
             .format(self.vm_name, self.resource_group, self.image,
                     self.size, self.vm_username, self.authentication_type,
-                    self.storage_account, self.os_disk_name)
+                    self.os_disk_name)
         if self.ssh_key_value:
             cmd += ' --ssh-key-value {}'.format(self.ssh_key_value)
         elif self.generate_ssh_keys:
@@ -426,7 +494,7 @@ class AzureVM(VM):
         if self.custom_data:
             cmd += ' --custom-data "{}"'.format(self.custom_data)
         if self.use_unmanaged_disk:
-            cmd += " --use-unmanaged-disk"
+            cmd += ' --use-unmanaged-disk --storage-account {}'.format(self.storage_account)
         if self.assign_identity:
             cmd += " --assign-identity"
             cmd += ' --scope "{}"'.format(self.scope)

--- a/tests/azure/test_functional_cloudinit.py
+++ b/tests/azure/test_functional_cloudinit.py
@@ -8,6 +8,7 @@ from avocado_cloud.app.azure import AzureAccount
 from avocado_cloud.app.azure import AzureNIC
 from avocado_cloud.app.azure import AzurePublicIP
 from avocado_cloud.app.azure import AzureNicIpConfig
+from avocado_cloud.app.azure import AzureImage
 from distutils.version import LooseVersion
 from avocado_cloud.utils.utils_azure import command
 
@@ -24,9 +25,15 @@ class CloudinitTest(Test):
             if LooseVersion(self.project) < LooseVersion('7.8'):
                 self.cancel(
                     "Skip case because RHEL-{} ondemand image doesn't support gen2".format(self.project))
-            cloud = Setup(self.params, self.name, size="DC2s")
+            cloud = Setup(self.params, self.name, size="DS2_v2")
         else:
             cloud = Setup(self.params, self.name)
+        if self.case_short_name == "test_cloudinit_provision_gen2_vm":
+            self.image = AzureImage(self.params, generation="V2")
+            self.image.create()
+            cloud.vm.image = self.image.name
+            cloud.vm.vm_name += "-gen2"
+            cloud.vm.use_unmanaged_disk = False
         self.vm = cloud.vm
         self.package = self.params.get("packages", "*/Other/*")
         if self.case_short_name in [


### PR DESCRIPTION
Add AzureImage class in azure/sdk.py. 
Create image before creating VM while running gen2 case to follow the MSFT recommended way in azure cloud-init test.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>