### PR TITLE
Add 3 Azure cloud-init cases

### DIFF
--- a/avocado_cloud/app/setup.py
+++ b/avocado_cloud/app/setup.py
@@ -28,7 +28,7 @@ class Setup(object):
         else:
             raise TestError()
 
-    def init_vm(self, pre_delete=False, pre_stop=False):
+    def init_vm(self, pre_delete=False, pre_stop=False, authentication="publickey"):
         if pre_delete and self.vm.exists():
             self.vm.delete(wait=True)
         if not self.vm.exists():
@@ -39,7 +39,7 @@ class Setup(object):
             self.vm.stop(wait=True)
         session = self.init_session()
         if self.vm.is_started():
-            session.connect(timeout=600)
+            session.connect(timeout=600, authentication=authentication)
         return session
 
     def init_session(self):

--- a/config/azure_testcases_cloudinit.yaml
+++ b/config/azure_testcases_cloudinit.yaml
@@ -20,6 +20,9 @@ cases:
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_provision_vm_with_sriov_nic
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_provision_vm_with_ipv6
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_provision_gen2_vm
-    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_login_with_password
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_storage_rule_gen1
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_storage_rule_gen2
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_multiple_files_in_authorizedkeysfile
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_customized_file_in_authorizedkeysfile
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_login_with_password
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_remove_cache_and_reboot_password


### PR DESCRIPTION
Add Azure cloud-init cases:
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_multiple_files_in_authorizedkeysfile
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_customized_file_in_authorizedkeysfile (skip now)
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_remove_cache_and_reboot_password

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>