### PR TITLE
Add one case 'test_cloudinit_check_config_ipv6' on openstack

### DIFF
--- a/avocado_cloud/app/openstack/sdk.py
+++ b/avocado_cloud/app/openstack/sdk.py
@@ -65,7 +65,7 @@ class OpenstackVM(VM):
             for ip in net:
                 if ip['OS-EXT-IPS:type'] == 'floating':
                     f_ip = ip['addr']
-                elif ip['OS-EXT-IPS:type'] == 'fixed':
+                elif ip['OS-EXT-IPS:type'] == 'fixed' and  ip['version']== 4:
                     f_ip = ip['addr']
         return f_ip
 

--- a/config/openstack_testcases_cloudinit.yaml
+++ b/config/openstack_testcases_cloudinit.yaml
@@ -7,6 +7,7 @@ cases:
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_log_no_critical
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_log_no_warn
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_log_no_error
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_config_ipv6
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_instance_data_json
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_create_vm_login_repeatedly
     test_functional_cloudinit.py:CloudinitTest.test_cloudutils_growpart_resize_partition_first_boot

--- a/tests/openstack/test_functional_cloudinit.py
+++ b/tests/openstack/test_functional_cloudinit.py
@@ -219,6 +219,19 @@ class CloudinitTest(Test):
                           msg='check /run/cloud-init/instance-data.json',
                           is_get_console=False)
 
+    def test_cloudinit_check_config_ipv6(self):
+        '''
+        :avocado: tags=tier2,cloudinit
+        polarion_id: RHEL-189023 - CLOUDINIT-TC: check ipv6 configuration
+        '''
+        self.session.connect(timeout=self.ssh_wait_timeout)
+        cmd = 'ifconfig eth0'
+        utils_lib.run_cmd(self, cmd, expect_kw='inet6 2620')
+        cmd = 'cat /etc/sysconfig/network-scripts/ifcfg-eth0'
+        utils_lib.run_cmd(self, cmd, expect_kw='IPV6INIT=yes')
+        utils_lib.run_cmd(self, 'uname -r', msg='Get instance kernel version')
+
+
     def test_cloudinit_create_vm_login_repeatedly(self):
         """
         :avocado: tags=tier3,cloudinit,test_cloudinit_create_vm_login_repeatedly
@@ -364,4 +377,6 @@ ssh_pwauth: 1
             "No sudo privilege")    
 
     def tearDown(self):
+        if self.name.name.endswith("test_cloudinit_login_with_password"):
+            self.vm.delete(wait=True)
         self.session.close()


### PR DESCRIPTION
1. Add one case 'test_cloudinit_check_config_ipv6' on openstack
2. Change the condition of getting foating_ip in openstack sdk
3. Delete VM created by case 'test_cloudinit_login_with_password' in tearDown

Signed-off-by: Xiaoyi Chen <xiachen@xiachen.nay.csb>