### PR TITLE
[Azure] Add ignorable cloud-init error log

### DIFF
--- a/data/azure/ignore_cloudinit_messages
+++ b/data/azure/ignore_cloudinit_messages
@@ -5,3 +5,4 @@ nofail
 Ran .* modules with 0 failures
 DEBUG.: Fetched.*mounts from proc
 finish: azure-ds/load_azure_ds_dir: FAIL: load_azure_ds_dir
+handlers.py.DEBUG.: diagnostic: diagnostic message: dhclient error stream: Internet Systems Consortium DHCP Client


### PR DESCRIPTION
Add ignorable cloud-init error log:
handlers.py[DEBUG]: diagnostic: diagnostic message: dhclient error stream: Internet Systems Consortium DHCP Client

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>