### PR TITLE
[Azure]WALA package doesn't use pulpcore repo

### DIFF
--- a/tests/azure/test_functional_package_preparation.py
+++ b/tests/azure/test_functional_package_preparation.py
@@ -93,7 +93,8 @@ EOF
 """.format(pulpcore_url)
         self.session.cmd_output("cat << EOF > /etc/yum.repos.d/rhel.repo%s" %
                                 (BASEREPO))
-        if requests.get(pulpcore_url).ok:
+        # WALA doesn't use pulpcore repo to avoid the RHEL-8.0 systemd update issue
+        if "WALinuxAgent" not in self.packages and requests.get(pulpcore_url).ok:
             self.session.cmd_output("cat << EOF >> /etc/yum.repos.d/rhel.repo%s" %
                                     (PULPCOREREPO))
         if x_version > 7:

--- a/tests/azure/test_functional_wala_network.py
+++ b/tests/azure/test_functional_wala_network.py
@@ -139,7 +139,7 @@ lo eth0\
         else:
             self.session.cmd_output(
                 "hostnamectl set-hostname {0}".format(new_hostname))
-        time.sleep(15)
+        time.sleep(30)
         self.assertNotIn(
             "NXDOMAIN",
             self.session.cmd_output("nslookup {0}".format(new_hostname)),
@@ -159,7 +159,7 @@ lo eth0\
         old_hostname = self.vm.vm_name
         new_hostname = self.vm.vm_name + "new"
         self.session.cmd_output("nmcli gen hostname {0}".format(new_hostname))
-        time.sleep(15)
+        time.sleep(30)
         # Check DNS
         self.assertNotIn(
             "NXDOMAIN",
@@ -210,7 +210,7 @@ lo eth0\
         else:
             self.error("Fail to start waagent -run-exthandlers process")
         # Sleep 15s to wait for waagent publishing hostname
-        time.sleep(15)
+        time.sleep(30)
         # Check DNS
         self.assertNotIn(
             "NXDOMAIN",
@@ -235,7 +235,7 @@ lo eth0\
             else:
                 self.session.cmd_output(
                     "hostnamectl set-hostname {0}".format(new_hostname))
-            time.sleep(10)
+            time.sleep(30)
             # Check DNS
             max_retry = 10
             for retry in range(1, max_retry + 1):


### PR DESCRIPTION
WALA package doesn't use pulpcore repo to prevent the RHEL-8.0 systemd update issue
Increase WALA network hostname cases wait time to 30s

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>