### PR TITLE
Stop NetworkManager before waagent deprovision or it will regenerate resolv.conf in RHEL-8.4

### DIFF
--- a/tests/azure/test_functional_wala_function.py
+++ b/tests/azure/test_functional_wala_function.py
@@ -37,6 +37,9 @@ class WALAFuncTest(Test):
         status, output = self.session.cmd_status_output('sudo su -')
         self.assertEqual(status, 0,
                          "User [root] login failed\n{}".format(str(output)))
+        # Must stop NetworkManager or it will regenerate /etc/resolv.conf in RHEL-8.4
+        if "test_waagent_depro" in self.case_short_name:
+            self.session.cmd_output("systemctl stop NetworkManager")
 
     def test_waagent_verbose(self):
         """


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>