### PR TITLE
[Azure] Add 3 cloud-init cases

### DIFF
--- a/config/azure_testcases_cloudinit.yaml
+++ b/config/azure_testcases_cloudinit.yaml
@@ -39,3 +39,6 @@ cases:
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_show_full_version
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_default_config
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_startup_time
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_lang_is_not_en_us_utf8
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_mount_with_noexec_option
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_no_networkmanager


### PR DESCRIPTION
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_lang_is_not_en_us_utf8
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_mount_with_noexec_option
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_no_networkmanager

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>