### PR TITLE
Update two cases per BZs

### DIFF
--- a/config/openstack_testcases_cloudinit.yaml
+++ b/config/openstack_testcases_cloudinit.yaml
@@ -29,3 +29,4 @@ cases:
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_ds_identify_found
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_check_resolv_conf_reboot
     test_functional_cloudinit.py:CloudinitTest.test_cloudinit_auto_install_package_with_subscription_manager
+    test_functional_cloudinit.py:CloudinitTest.test_cloudinit_verify_customized_file_in_authorizedkeysfile


### PR DESCRIPTION
Update two cloud-init cases on openstack:    
test_cloudinit_verify_customized_file_in_authorizedkeysfile
test_cloudinit_verify_multiple_files_in_authorizedkeysfile
