### PR TITLE
Enhance local disk and cloud disk test cases for Aliyun

### DIFF
--- a/avocado_cloud/app/alibaba/sdk.py
+++ b/avocado_cloud/app/alibaba/sdk.py
@@ -23,6 +23,8 @@ class AlibabaVM(VM):
         self.disk_count = params.get('disk_count', '*/Flavor/*', 0)
         self.disk_size = params.get('disk_size', '*/Flavor/*', 0)
         self.disk_type = params.get('disk_type', '*/Flavor/*', '')
+        self.local_disk_driver = params.get('local_disk_driver', '*/Flavor/*', 'virtio_blk')
+        self.cloud_disk_driver = params.get('cloud_disk_driver', '*/Flavor/*', 'virtio_blk')
         self.nic_count = params.get('nic_count', '*/Flavor/*', 1)
         self.disk_quantity = params.get('disk_quantity', '*/Flavor/*', 0)
 

--- a/tests/alibaba/test_functional_clouddisk.py
+++ b/tests/alibaba/test_functional_clouddisk.py
@@ -9,7 +9,7 @@ class CloudDiskTest(Test):
         self.vm = self.cloud.vm
         pre_delete = False
         pre_stop = False
-        if self.name.name.endswith("test_offline_attach_detach_cloud_disks"):
+        if self.name.name.endswith('test_offline_attach_detach_cloud_disks'):
             pre_stop = True
         self.session = self.cloud.init_vm(pre_delete=pre_delete,
                                           pre_stop=pre_stop)
@@ -27,12 +27,12 @@ class CloudDiskTest(Test):
         self.local_disk_size = self.vm.disk_size
         self.local_disk_type = self.vm.disk_type
 
-        if self.name.name.endswith("test_local_disks"):
+        if self.name.name.endswith('test_local_disks'):
             if self.local_disk_count == 0:
-                self.cancel("No local disk. Skip this case.")
+                self.cancel('No local disk. Skip this case.')
 
         self.disk_ids = self.cloud.init_cloud_disks(self.cloud_disk_count)
-        self.dev_name = "vd"
+        self.dev_name = 'vd'
 
     def _disk_test(self, disk_type, initial, disk_count, disk_size):
         self.log.debug('Function _disk_test: type={}, init={}, count={}, size={}'.format(
@@ -40,8 +40,8 @@ class CloudDiskTest(Test):
 
         dev_names = []
         for i in range(1, disk_count + 1):
-            if disk_type == "nvme":
-                dev_fullname = "nvme%sn1" % (initial + i - 1)
+            if disk_type == 'nvme':
+                dev_fullname = 'nvme%sn1' % (initial + i - 1)
             else:
                 delta = ord(initial) - 97 + i
                 if delta <= 26:
@@ -60,7 +60,7 @@ class CloudDiskTest(Test):
         self.log.debug('Function _verify_disk: name={}, size={}'.format(
             dev_fullname, disk_size))
 
-        cmd = "fdisk -l /dev/{0} | grep /dev/{0}"
+        cmd = 'fdisk -l /dev/{0} | grep /dev/{0}'
         output = self.session.cmd_output(cmd.format(dev_fullname))
 
         # WORKAROUND: Alibaba local volume untrimmed issue
@@ -71,74 +71,59 @@ class CloudDiskTest(Test):
                     dev_fullname))
             output = self.session.cmd_output(cmd.format(dev_fullname))
 
-        # if output.split(',')[0].split(' ')[3] == "GB":
-        #     expected_size = float(disk_size)*(1.024**3)
-        # elif output.split(',')[0].split(' ')[3] == "GiB":
-        #     expected_size = float(disk_size)
-        # else:
-        #     self.fail("Attach disk size unit is not GB or GiB.")
-        #
-        # real_size = float(output.split(',')[0].split(' ')[2])
-
-        # Get the real size in bytes
-        # The outputs for `fdisk -l /dev/{0} | grep /dev/{0}`:
-        # (RHEL7.6)
-        # Disk /dev/vdd: 107.4 GB, 107374182400 bytes, 209715200 sectors
-        # (RHEL8.0)
-        # Disk /dev/vdb: 1.8 TiB, 1919850381312 bytes, 3749707776 sectors
-        if output.split(',')[1].split(' ')[2] == "bytes":
+        if output.split(',')[1].split(' ')[2] == 'bytes':
             real_size = int(output.split(',')[1].split(' ')[1])
         else:
-            self.fail("Fail to get the real disk size.")
+            self.fail('Fail to get the real disk size.')
 
         # The disk_size was specified in GiB, should covert to bytes
         expected_size = int(disk_size) * (1024**3)
 
         self.log.info(
-            "real_size: {0}; expected_size: {1}; delta: 1/1000.".format(
+            'real_size: {0}; expected_size: {1}; delta: 1/1000.'.format(
                 real_size, expected_size))
 
         self.assertAlmostEqual(first=real_size,
                                second=expected_size,
                                delta=expected_size / 1000.0,
-                               msg="Attach disk size is not as expected.\n\
-Real: {0}; Expected: {1}".format(real_size, expected_size))
+                               msg='Attach disk size is not as expected.\n\
+Real: {0}; Expected: {1}'.format(real_size, expected_size))
 
         # Make a 10GB partition in case the whole disk is too large (1800G for
         # local disk)
-        cmd = "parted /dev/{0} mklabel msdos -s"
+        cmd = 'parted /dev/{0} mklabel msdos -s'
         self.session.cmd_output(cmd.format(dev_fullname))
-        cmd = "parted /dev/{0} mkpart primary ext4 0 10GB -s"
+        cmd = 'parted /dev/{0} mkpart primary ext4 0 10GB -s'
         self.session.cmd_output(cmd.format(dev_fullname))
-        # cmd = "fdisk -l /dev/{0}|grep -o '^/dev/[a-z0-9]*'|cut -b 6-"
+        # cmd = 'fdisk -l /dev/{0}|grep -o '^/dev/[a-z0-9]*'|cut -b 6-'
         # part_fullname = self.session.cmd_output(cmd.format(dev_fullname))
-        cmd = "fdisk -l /dev/{0}|grep -o '^/dev/[a-z0-9]*'"
+        cmd = 'fdisk -l /dev/{0}|grep -o "^/dev/[a-z0-9]*"'
         part_fullname = self.session.cmd_output(
-            cmd.format(dev_fullname)).strip().split(" ")[0].split("/")[2]
-        cmd = "[[ -d /mnt/{0} ]] || mkdir /mnt/{0}"
+            cmd.format(dev_fullname)).strip().split(' ')[0].split('/')[2]
+        cmd = '[[ -d /mnt/{0} ]] || mkdir /mnt/{0}'
         self.session.cmd_output(cmd.format(part_fullname))
-        cmd = "mkfs.ext4 -F /dev/{0};mount /dev/{0} /mnt/{0} && \
-echo test_content > /mnt/{0}/test_file"
+        cmd = 'mkfs.ext4 -F /dev/{0};mount /dev/{0} /mnt/{0} && \
+echo test_content > /mnt/{0}/test_file'
 
         self.session.cmd_output(cmd.format(part_fullname), timeout=60)
-        cmd = "cat /mnt/{0}/test_file"
+        cmd = 'cat /mnt/{0}/test_file'
         output = self.session.cmd_output(cmd.format(part_fullname))
         self.assertEqual(
-            output, "test_content",
-            "Cannot write files on attached disk.\n {0}".format(output))
-        cmd = "umount /mnt/{0}"
+            output, 'test_content',
+            'Cannot write files on attached disk.\n {0}'.format(output))
+        cmd = 'umount /mnt/{0}'
         self.session.cmd_output(cmd.format(part_fullname))
-        cmd = "parted /dev/{0} rm 1"
+        cmd = 'parted /dev/{0} rm 1'
         self.session.cmd_output(cmd.format(dev_fullname))
 
     def test_online_attach_detach_cloud_disks(self):
-        self.log.info("Online attach a cloud disk to VM")
+        self.log.info('Online attach a cloud disk to VM')
 
         vols = self.vm.query_cloud_disks()
         for vol in vols:
-            s = vol.get("status") or vol.get("Status")
+            s = vol.get('status') or vol.get('Status')
             self.assertEqual(s.lower(), u'available',
-                             "Disk status is not available")
+                             'Disk status is not available')
 
         for disk_id in self.disk_ids:
             self.vm.attach_cloud_disks(
@@ -146,16 +131,11 @@ echo test_content > /mnt/{0}/test_file"
 
         vols = self.vm.query_cloud_disks()
         for vol in vols:
-            s = vol.get("status") or vol.get("Status")
-            self.assertEqual(s.lower().replace('_', '-'), u"in-use",
-                             "Disk status is not in-use")
+            s = vol.get('status') or vol.get('Status')
+            self.assertEqual(s.lower().replace('_', '-'), u'in-use',
+                             'Disk status is not in-use')
 
         self.session.cmd_output('sudo su -')
-
-        # if self.local_disk_type in ('ssd', 'hdd'):  # for alibaba
-        #     self._cloud_disk_test(initial=chr(98 + self.local_disk_count))
-        # else:
-        #     self._cloud_disk_test()
 
         # Test cloud disks
         self.log.debug('self.cloud_disk_driver = {}'.format(
@@ -166,8 +146,12 @@ echo test_content > /mnt/{0}/test_file"
             self.cloud_disk_size))
         self.log.debug('self.local_disk_driver = {}'.format(
             self.local_disk_driver))
+        self.log.debug('self.local_disk_type = {}'.format(
+            self.local_disk_type))
         self.log.debug('self.local_disk_count = {}'.format(
             self.local_disk_count))
+        self.log.debug('self.local_disk_size = {}'.format(
+            self.local_disk_size))
 
         if self.cloud_disk_driver not in ('virtio_blk', 'nvme'):
             self.fail('Unsuported cloud_disk_driver "{}".'.format(
@@ -199,33 +183,22 @@ echo test_content > /mnt/{0}/test_file"
                                     disk_size=self.cloud_disk_size)
         self.log.debug('dev_names = {}'.format(dev_names))
 
-        self.log.info("Online detach a cloud disk to VM")
+        self.log.info('Online detach a cloud disk to VM')
 
         for disk_id in self.disk_ids:
             self.vm.detach_cloud_disks(disk_id=disk_id, wait=True)
 
         vols = self.vm.query_cloud_disks()
         for vol in vols:
-            s = vol.get("status") or vol.get("Status")
+            s = vol.get('status') or vol.get('Status')
             self.assertEqual(s.lower(), u'available',
-                             "Disk status is not available")
+                             'Disk status is not available')
 
         for dev in dev_names:
             cmd = 'fdisk -l /dev/{} 2>/dev/null'.format(dev)
             output = self.session.cmd_output(cmd)
             self.assertEqual(
-                output, "", "Disk not detached.\n {}".format(output))
-
-        # for i in range(1, self.cloud_disk_count + 1):
-        #     delta = self.local_disk_count + i
-        #     if delta <= 25:
-        #         idx = chr(97 + delta)
-        #     else:
-        #         idx = 'a' + chr(97 - 1 + delta % 25)
-        #     cmd = 'fdisk -l /dev/%s%s 2>/dev/null'
-        #     output = self.session.cmd_output(cmd % (self.dev_name, idx))
-        #     self.assertEqual(output, "",
-        #                      "Disk not detached.\n {0}".format(output))
+                output, '', 'Disk not detached.\n {}'.format(output))
 
     def test_offline_attach_detach_cloud_disks(self):
         # Set timeout for Alibaba baremetal
@@ -234,13 +207,13 @@ echo test_content > /mnt/{0}/test_file"
         else:
             connect_timeout = 120
 
-        self.log.info("Offline attach a cloud disk to VM")
+        self.log.info('Offline attach a cloud disk to VM')
 
         vols = self.vm.query_cloud_disks()
         for vol in vols:
-            s = vol.get("status") or vol.get("Status")
+            s = vol.get('status') or vol.get('Status')
             self.assertEqual(s.lower(), u'available',
-                             "Disk status is not available")
+                             'Disk status is not available')
 
         for disk_id in self.disk_ids:
             self.vm.attach_cloud_disks(
@@ -248,16 +221,16 @@ echo test_content > /mnt/{0}/test_file"
 
         vols = self.vm.query_cloud_disks()
         for vol in vols:
-            s = vol.get("status") or vol.get("Status")
-            self.assertEqual(s.lower().replace('_', '-'), u"in-use",
-                             "Disk status is not in-use")
+            s = vol.get('status') or vol.get('Status')
+            self.assertEqual(s.lower().replace('_', '-'), u'in-use',
+                             'Disk status is not in-use')
 
         self.vm.start(wait=True)
         self.session.connect(timeout=connect_timeout)
         output = self.session.cmd_output('whoami')
         self.assertEqual(
             self.vm.vm_username, output,
-            "Start VM error: output of cmd `who` unexpected -> %s" % output)
+            'Start VM error: output of cmd `who` unexpected -> %s' % output)
         self.session.cmd_output('sudo su -')
 
         # Test cloud disks
@@ -269,8 +242,12 @@ echo test_content > /mnt/{0}/test_file"
             self.cloud_disk_size))
         self.log.debug('self.local_disk_driver = {}'.format(
             self.local_disk_driver))
+        self.log.debug('self.local_disk_type = {}'.format(
+            self.local_disk_type))
         self.log.debug('self.local_disk_count = {}'.format(
             self.local_disk_count))
+        self.log.debug('self.local_disk_size = {}'.format(
+            self.local_disk_size))
 
         if self.cloud_disk_driver not in ('virtio_blk', 'nvme'):
             self.fail('Unsuported cloud_disk_driver "{}".'.format(
@@ -302,37 +279,37 @@ echo test_content > /mnt/{0}/test_file"
                                     disk_size=self.cloud_disk_size)
         self.log.debug('dev_names = {}'.format(dev_names))
 
-        self.log.info("Offline detach a cloud disk to VM")
+        self.log.info('Offline detach a cloud disk to VM')
 
         self.vm.stop(wait=True)
         self.assertTrue(self.vm.is_stopped(),
-                        "Stop VM error: VM status is not SHUTOFF")
+                        'Stop VM error: VM status is not SHUTOFF')
 
         for disk_id in self.disk_ids:
             self.vm.detach_cloud_disks(disk_id=disk_id, wait=True)
 
         vols = self.vm.query_cloud_disks()
         for vol in vols:
-            s = vol.get("status") or vol.get("Status")
+            s = vol.get('status') or vol.get('Status')
             self.assertEqual(s.lower(), u'available',
-                             "Disk status is not available")
+                             'Disk status is not available')
 
         self.vm.start(wait=True)
         self.session.connect(timeout=connect_timeout)
         output = self.session.cmd_output('whoami')
         self.assertEqual(
             self.vm.vm_username, output,
-            "Start VM error: output of cmd `who` unexpected -> %s" % output)
+            'Start VM error: output of cmd `who` unexpected -> %s' % output)
         self.session.cmd_output('sudo su -')
 
         for dev in dev_names:
             cmd = 'fdisk -l /dev/{} 2>/dev/null'.format(dev)
             output = self.session.cmd_output(cmd)
             self.assertEqual(
-                output, "", "Disk not detached.\n {}".format(output))
+                output, '', 'Disk not detached.\n {}'.format(output))
 
     def test_local_disks(self):
-        self.log.info("Test local disks on VM")
+        self.log.info('Test local disks on VM')
         self.session.cmd_output('sudo su -')
 
         # Test local disks
@@ -382,4 +359,4 @@ echo test_content > /mnt/{0}/test_file"
         self.log.debug('dev_names = {}'.format(dev_names))
 
     def tearDown(self):
-        self.log.info("TearDown")
+        self.log.info('TearDown')

--- a/tests/alibaba/test_functional_clouddisk.py
+++ b/tests/alibaba/test_functional_clouddisk.py
@@ -178,7 +178,7 @@ echo test_content > /mnt/{0}/test_file"
                 self.local_disk_driver))
 
         if self.cloud_disk_driver == 'virtio_blk':
-            _disk_type = 'ssd'
+            _disk_type = 'cloud_ssd'
             if self.local_disk_driver == 'nvme':
                 _initial = 'b'
             else:
@@ -193,10 +193,10 @@ echo test_content > /mnt/{0}/test_file"
         self.log.debug('_disk_type = {}'.format(_disk_type))
         self.log.debug('_initial = {}'.format(_initial))
 
-        dev_names = self._cloud_disk_test(disk_type=_disk_type,
-                                          initial=_initial,
-                                          disk_count=self.cloud_disk_count,
-                                          disk_size=self.cloud_disk_size)
+        dev_names = self._disk_test(disk_type=_disk_type,
+                                    initial=_initial,
+                                    disk_count=self.cloud_disk_count,
+                                    disk_size=self.cloud_disk_size)
         self.log.debug('dev_names = {}'.format(dev_names))
 
         self.log.info("Online detach a cloud disk to VM")
@@ -281,7 +281,7 @@ echo test_content > /mnt/{0}/test_file"
                 self.local_disk_driver))
 
         if self.cloud_disk_driver == 'virtio_blk':
-            _disk_type = 'ssd'
+            _disk_type = 'cloud_ssd'
             if self.local_disk_driver == 'nvme':
                 _initial = 'b'
             else:
@@ -296,10 +296,10 @@ echo test_content > /mnt/{0}/test_file"
         self.log.debug('_disk_type = {}'.format(_disk_type))
         self.log.debug('_initial = {}'.format(_initial))
 
-        dev_names = self._cloud_disk_test(disk_type=_disk_type,
-                                          initial=_initial,
-                                          disk_count=self.cloud_disk_count,
-                                          disk_size=self.cloud_disk_size)
+        dev_names = self._disk_test(disk_type=_disk_type,
+                                    initial=_initial,
+                                    disk_count=self.cloud_disk_count,
+                                    disk_size=self.cloud_disk_size)
         self.log.debug('dev_names = {}'.format(dev_names))
 
         self.log.info("Offline detach a cloud disk to VM")
@@ -334,11 +334,52 @@ echo test_content > /mnt/{0}/test_file"
     def test_local_disks(self):
         self.log.info("Test local disks on VM")
         self.session.cmd_output('sudo su -')
-        initial = 'b'
-        self._cloud_disk_test(initial=initial,
-                              disk_count=self.local_disk_count,
-                              disk_type=self.local_disk_type,
-                              disk_size=self.local_disk_size)
+
+        # Test local disks
+        self.log.debug('self.cloud_disk_driver = {}'.format(
+            self.cloud_disk_driver))
+        self.log.debug('self.cloud_disk_count = {}'.format(
+            self.cloud_disk_count))
+        self.log.debug('self.cloud_disk_size = {}'.format(
+            self.cloud_disk_size))
+        self.log.debug('self.local_disk_driver = {}'.format(
+            self.local_disk_driver))
+        self.log.debug('self.local_disk_type = {}'.format(
+            self.local_disk_type))
+        self.log.debug('self.local_disk_count = {}'.format(
+            self.local_disk_count))
+        self.log.debug('self.local_disk_size = {}'.format(
+            self.local_disk_size))
+
+        if self.cloud_disk_driver not in ('virtio_blk', 'nvme'):
+            self.fail('Unsuported cloud_disk_driver "{}".'.format(
+                self.cloud_disk_driver))
+
+        if self.local_disk_driver not in ('virtio_blk', 'nvme'):
+            self.fail('Unsuported local_disk_driver "{}".'.format(
+                self.local_disk_driver))
+
+        if self.local_disk_driver == 'virtio_blk':
+            _disk_type = self.local_disk_type
+            if self.cloud_disk_driver == 'nvme':
+                _initial = 'a'
+            else:
+                _initial = 'b'
+        else:
+            _disk_type = 'nvme'
+            if self.cloud_disk_driver == 'nvme':
+                _initial = 1
+            else:
+                _initial = 0
+
+        self.log.debug('_disk_type = {}'.format(_disk_type))
+        self.log.debug('_initial = {}'.format(_initial))
+
+        dev_names = self._disk_test(disk_type=_disk_type,
+                                    initial=_initial,
+                                    disk_count=self.local_disk_count,
+                                    disk_size=self.local_disk_size)
+        self.log.debug('dev_names = {}'.format(dev_names))
 
     def tearDown(self):
         self.log.info("TearDown")


### PR DESCRIPTION
```
# ecs.i2
JOB ID     : d35b1a1e3141f389edc8dbd3e4b6c5c9ef741424
JOB LOG    : /root/avocado/job-results/job-2022-03-21T04.53-d35b1a1/job.log
(1/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_local_disks;Cloud-Credential-Disk-ecs.i2.2xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-8c89:  PASS (3.47 s)
(2/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_online_attach_detach_cloud_disks;Cloud-Credential-Disk-ecs.i2.2xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-8c89:  PASS (208.95 s)
(3/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_offline_attach_detach_cloud_disks;Cloud-Credential-Disk-ecs.i2.2xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-8c89:  PASS (408.24 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 621.52 s
JOB HTML   : /root/avocado/job-results/job-2022-03-21T04.53-d35b1a1/results.html

# ecs.i3
JOB ID     : a0849b2ea8acb5a5d0670104fe74226138e24afb
JOB LOG    : /root/avocado/job-results/job-2022-03-21T05.12-a0849b2/job.log
(1/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_local_disks;Cloud-Credential-Disk-ecs.i3.8xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-e8f8:  PASS (141.40 s)
(2/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_online_attach_detach_cloud_disks;Cloud-Credential-Disk-ecs.i3.8xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-e8f8:  PASS (217.34 s)
(3/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_offline_attach_detach_cloud_disks;Cloud-Credential-Disk-ecs.i3.8xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-e8f8:  PASS (465.32 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 824.90 s
JOB HTML   : /root/avocado/job-results/job-2022-03-21T05.12-a0849b2/results.html

# ecs.g7se
JOB ID     : cd21060c5c66cdf32f88e4983ae08ab5c5210441
JOB LOG    : /root/avocado/job-results/job-2022-03-21T06.39-cd21060/job.log
(1/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_local_disks;Cloud-Credential-Disk-ecs.g7se.4xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-3c35:  CANCEL (2.78 s)
(2/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_online_attach_detach_cloud_disks;Cloud-Credential-Disk-ecs.g7se.4xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-3c35:  PASS (321.08 s)
(3/3) /app/tests/alibaba/test_functional_clouddisk.py:CloudDiskTest.test_offline_attach_detach_cloud_disks;Cloud-Credential-Disk-ecs.g7se.4xlarge-Image-NIC-VSwitch-SecurityGroup-password-username-VM-3c35:  PASS (575.37 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 900.08 s
JOB HTML   : /root/avocado/job-results/job-2022-03-21T06.39-cd21060/results.html
```