### PR TITLE
Fix some issues for azure cloud-init

### DIFF
--- a/data/azure/default_cloud_90.cfg
+++ b/data/azure/default_cloud_90.cfg
@@ -1,0 +1,69 @@
+users:
+ - default
+
+disable_root: 1
+ssh_pwauth:   0
+
+mount_default_fields: [~, ~, 'auto', 'defaults,nofail,x-systemd.requires=cloud-init.service,_netdev', '0', '2']
+resize_rootfs_tmp: /dev
+ssh_deletekeys:   1
+ssh_genkeytypes:  ['rsa', 'ecdsa', 'ed25519']
+syslog_fix_perms: ~
+disable_vmware_customization: false
+
+cloud_init_modules:
+ - disk_setup
+ - migrator
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - rsyslog
+ - users-groups
+ - ssh
+
+cloud_config_modules:
+ - mounts
+ - locale
+ - set-passwords
+ - rh_subscription
+ - yum-add-repo
+ - package-update-upgrade-install
+ - timezone
+ - puppet
+ - chef
+ - salt-minion
+ - mcollective
+ - disable-ec2-metadata
+ - runcmd
+
+cloud_final_modules:
+ - rightscale_userdata
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - phone-home
+ - final-message
+ - power-state-change
+
+system_info:
+  default_user:
+    name: cloud-user
+    lock_passwd: true
+    gecos: Cloud User
+    groups: [adm, systemd-journal]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+  distro: rhel
+  paths:
+    cloud_dir: /var/lib/cloud
+    templates_dir: /etc/cloud/templates
+  ssh_svcname: sshd
+
+# vim:syntax=yaml


### PR DESCRIPTION
1. For test_cloudinit_check_random_password_len, extend sleep time to make sure the serial console refresh finished.
2. For test_cloudinit_check_default_config, The default cloud.cfg is different in rhel-9.0 as bz 1998445, fix script to diff rhel-9.0 and other rhel-versions.
3. For test_cloudinit_dhclient_hook_disable_cloudinit, changing redeploy VM to cleanup/restart VM