### PR TITLE
Update cloud-init cases about status of running or done

### DIFF
--- a/tests/azure/test_functional_cloudinit.py
+++ b/tests/azure/test_functional_cloudinit.py
@@ -1601,7 +1601,10 @@ ssh_pwauth: 1
             self.error("Bootup is not finished in 100s. Exit.")
         for line in self.session.cmd_output("systemd-analyze blame|grep -E '(cloud-init-local|cloud-init|cloud-final|cloud-config)'|sed 's/^ *//g'").split('\n'):
             real_time, service = line.split(' ')
-            real_time = float(real_time.rstrip('s'))
+            if real_time.endswith('ms'):
+                real_time = 1
+            else:
+                real_time = float(real_time.rstrip('s'))
             total += real_time
             self.assertTrue(real_time < limit, "{} service startup time is {}s >= {}s".format(service, real_time, limit))
         self.assertTrue(total < total_limit, "All the services startup time is {}s >= {}s".format(total, total_limit))


### PR DESCRIPTION
Fix the issue that cloud-init status is running
    _check_cloudinit_done_and_service_isactive
    test_cloudinit_login_with_password
    test_cloudinit_create_vm_config_drive
    test_cloudinit_create_vm_two_nics
    test_cloudinit_create_vm_stateless_ipv6
    test_cloudinit_create_vm_stateful_ipv6
    test_cloudinit_auto_install_package_with_subscription_manager
Fix azure case 'ms' issue
    test_cloudinit_check_startup_time

Signed-off-by: Amy Chen <xiachen@redhat.com>