### PR TITLE
Set ssh_pwauth: 0 to trigger sshd service restart in openstack cloud-init

### DIFF
--- a/tests/openstack/test_functional_cloudinit.py
+++ b/tests/openstack/test_functional_cloudinit.py
@@ -59,6 +59,7 @@ class CloudinitTest(Test):
                 "test_cloudinit_boot_time"):
             pre_delete = True
         #below data is used for the login case and other cases except above specific cases.
+        #set ssh_pwauth: 0 to trigger sshd service restart, bz#2091217
         user_data = """\
 #cloud-config
 
@@ -68,7 +69,7 @@ runcmd:
 user: {0}
 password: {1}
 chpasswd: {{ expire: False }}
-ssh_pwauth: 1
+ssh_pwauth: 0
 """.format(self.vm.vm_username, 'R')# test random password
         self.vm.user_data = base64.b64encode(
         user_data.encode('utf-8')).decode('utf-8')


### PR DESCRIPTION
In rhel-guest-image, /etc/ssh/sshd_config default value is PasswordAuthentication yes
To trigger sshd service restart in openstack cloud-init case, we should set ssh_pwauth: 0

Signed-off-by: Amy Chen <xiachen@redhat.com>