### PR TITLE
Add checkpoints for kernel parameters on RHEL9 and modify test_assign_unassign_secondary_private_ips test case

### DIFF
--- a/avocado_cloud/app/alibaba/sdk.py
+++ b/avocado_cloud/app/alibaba/sdk.py
@@ -27,6 +27,7 @@ class AlibabaVM(VM):
         self.cloud_disk_driver = params.get('cloud_disk_driver', '*/Flavor/*', 'virtio_blk')
         self.nic_count = params.get('nic_count', '*/Flavor/*', 1)
         self.disk_quantity = params.get('disk_quantity', '*/Flavor/*', 0)
+        self.private_ip_quantity = params.get('private_ip_quantity', '*/Flavor/*', 1)
 
         # VM access parameters
         self.vm_username = params.get('username', '*/VM/*')

--- a/data/alibaba/cmdline_params.el9.lst
+++ b/data/alibaba/cmdline_params.el9.lst
@@ -1,3 +1,5 @@
 no_timer_check
 console=ttyS0,115200n8
 net.ifnames=0
+crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M
+crash_kexec_post_notifiers=1

--- a/tests/alibaba/test_functional_network.py
+++ b/tests/alibaba/test_functional_network.py
@@ -260,7 +260,7 @@ class NetworkTest(Test):
             n/a
         polarion_id:
             https://polarion.engineering.redhat.com/polarion/#/project/\
-            RedHatEnterpriseLinux7/workitems?query=title:\
+            RHELVIRT/workitems?query=title:\
             "[Aliyun]NetworkTest.test_assign_unassign_secondary_private_ips"
         maintainer:
             yoguo@redhat.com
@@ -284,7 +284,10 @@ class NetworkTest(Test):
             All the functionality works well.
         """
         # Assign multiple secondary private ips
-        secondary_private_ip_count = 3
+        if self.vm.private_ip_quantity < 2:
+            self.cancel('Only 1 primary private ip is supported. Skip this case.')
+
+        secondary_private_ip_count = self.vm.private_ip_quantity - 1
         ret = self.vm.assign_secondary_private_ips(self.primary_nic_id, secondary_private_ip_count)
         private_ip_list = ret.get("AssignedPrivateIpAddressesSet").get("PrivateIpSet").get("PrivateIpAddress")
         self.assertEqual(len(private_ip_list), secondary_private_ip_count,
@@ -292,7 +295,7 @@ class NetworkTest(Test):
 
         # Unassign multiple secondary private ips
         self.vm.unassign_secondary_private_ips(self.primary_nic_id, private_ip_list)
-        time.sleep(5)
+        time.sleep(10)
 
         private_ip_list = []
         for nic in self.vm.query_nics():


### PR DESCRIPTION
1. Add checkpoints for kernel parameters on RHEL9
2. Modify the previous test case(test_assign_unassign_secondary_private_ips)