### PR TITLE
Some changes for RHEL8.6 arm image and RHEL9.0 image

### DIFF
--- a/avocado_cloud/app/alibaba/sdk.py
+++ b/avocado_cloud/app/alibaba/sdk.py
@@ -34,7 +34,7 @@ class AlibabaVM(VM):
         self.vm_username = params.get('username', '*/VM/*')
         self.vm_password = params.get('password', '*/VM/*')
 
-        self.arch = 'x86_64'
+        self.arch = params.get('arch', '*/Flavor/*', 'x86_64')
 
         self.ecs = AlibabaSDK(params)
 

--- a/data/alibaba/rogue.el8.lst
+++ b/data/alibaba/rogue.el8.lst
@@ -9,6 +9,7 @@
 /etc/alternatives/ifdown
 /etc/alternatives/ifup
 /etc/alternatives/libnssckbi.so.x86_64
+/etc/alternatives/libnssckbi.so
 /etc/authselect/authselect.conf
 /etc/authselect/dconf-db
 /etc/authselect/dconf-locks
@@ -231,6 +232,7 @@
 /etc/yum.repos.d/rhel.repo
 /initrd.root.sqsh
 /etc/systemd/system/multi-user.target.wants/remote-cryptsetup.target
+/etc/cloud/cloud.cfg.d/aliyun_cloud.cfg
 #################### KNOWN ISSUES BELOW ####################
 /etc/redhat-access-insights/.lastupload
 /etc/redhat-access-insights/machine-id

--- a/data/alibaba/rogue.el9.lst
+++ b/data/alibaba/rogue.el9.lst
@@ -9,6 +9,7 @@
 /etc/alternatives/ifdown
 /etc/alternatives/ifup
 /etc/alternatives/libnssckbi.so.x86_64
+/etc/alternatives/libnssckbi.so
 /etc/authselect/authselect.conf
 /etc/authselect/dconf-db
 /etc/authselect/dconf-locks
@@ -246,6 +247,23 @@
 /etc/systemd/user/timers.target.wants/systemd-tmpfiles-clean.timer
 /etc/cloud/cloud.cfg.d/aliyun_cloud.cfg
 /etc/cloud/cloud.cfg.d/aliyun_ebm.cfg.bak
+/etc/alternatives/arptables
+/etc/alternatives/arptables-helper
+/etc/alternatives/arptables-man
+/etc/alternatives/arptables-restore
+/etc/alternatives/arptables-restore-man
+/etc/alternatives/arptables-save
+/etc/alternatives/arptables-save-man
+/etc/alternatives/ebtables
+/etc/alternatives/ebtables-man
+/etc/alternatives/ebtables-restore
+/etc/alternatives/ebtables-save
+/etc/alternatives/ip6tables
+/etc/alternatives/ip6tables-restore
+/etc/alternatives/ip6tables-save
+/etc/alternatives/iptables
+/etc/alternatives/iptables-restore
+/etc/alternatives/iptables-save
 #################### KNOWN ISSUES BELOW ####################
 /etc/redhat-access-insights/.lastupload
 /etc/redhat-access-insights/machine-id

--- a/data/alibaba/rpm_va.el8.lst
+++ b/data/alibaba/rpm_va.el8.lst
@@ -75,5 +75,13 @@ SM5....T.  c /boot/grub2/grubenv
 S.5....T.  c /etc/containers/registries.conf
 .M...UG..    /run/uuidd
 SM5..UGT.  c /etc/cloud/cloud.cfg
+.......T.    /boot/efi/EFI/redhat/grubaa64.efi
+.......T.    /boot/efi/EFI/BOOT/BOOTAA64.EFI
+.......T.    /boot/efi/EFI/BOOT/fbaa64.efi
+.......T.    /boot/efi/EFI/redhat/BOOTAA64.CSV
+.......T.    /boot/efi/EFI/redhat/mmaa64.efi
+.......T.    /boot/efi/EFI/redhat/shim.efi
+.......T.    /boot/efi/EFI/redhat/shimaa64-redhat.efi
+.......T.    /boot/efi/EFI/redhat/shimaa64.efi
 #################### KNOWN ISSUES BELOW ####################
 S.5....T.    /usr/lib/systemd/system/cloud-init.service

--- a/data/alibaba/rpm_va.el9.lst
+++ b/data/alibaba/rpm_va.el9.lst
@@ -76,5 +76,12 @@ S.5....T.  c /etc/containers/registries.conf
 .M...UG..    /run/uuidd
 .M.....T.    /boot/grub2/fonts/unicode.pf2
 .......T.    /boot/efi/EFI/redhat/shim.efi
+.......T.    /boot/efi/EFI/redhat/grubaa64.efi
+.......T.    /boot/efi/EFI/BOOT/BOOTAA64.EFI
+.......T.    /boot/efi/EFI/BOOT/fbaa64.efi
+.......T.    /boot/efi/EFI/redhat/BOOTAA64.CSV
+.......T.    /boot/efi/EFI/redhat/mmaa64.efi
+.......T.    /boot/efi/EFI/redhat/shimaa64-redhat.efi
+.......T.    /boot/efi/EFI/redhat/shimaa64.efi
 #################### KNOWN ISSUES BELOW ####################
 S.5....T.    /usr/lib/systemd/system/cloud-init.service

--- a/data/alibaba/vulnerabilities.el8.lst
+++ b/data/alibaba/vulnerabilities.el8.lst
@@ -9,7 +9,9 @@ mds:Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknow
 meltdown:Mitigation: PTI
 meltdown:Not affected
 spec_store_bypass:Mitigation: Speculative Store Bypass disabled via prctl and seccomp
+spec_store_bypass:Mitigation: Speculative Store Bypass disabled via prctl
 spec_store_bypass:Vulnerable
+spectre_v1:Mitigation: __user pointer sanitization
 spectre_v1:Mitigation: usercopy/swapgs barriers and __user pointer sanitization
 spectre_v2:Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling
 spectre_v2:Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling

--- a/data/alibaba/vulnerabilities.el9.lst
+++ b/data/alibaba/vulnerabilities.el9.lst
@@ -11,6 +11,7 @@ meltdown:Not affected
 spec_store_bypass:Mitigation: Speculative Store Bypass disabled via prctl and seccomp
 spec_store_bypass:Mitigation: Speculative Store Bypass disabled via prctl
 spec_store_bypass:Vulnerable
+spectre_v1:Mitigation: __user pointer sanitization
 spectre_v1:Mitigation: usercopy/swapgs barriers and __user pointer sanitization
 spectre_v2:Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling
 spectre_v2:Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling

--- a/tests/alibaba/test_functional_checkup.py
+++ b/tests/alibaba/test_functional_checkup.py
@@ -669,6 +669,12 @@ will not check kernel-devel package.')
             if output.startswith("redhat-release"):
                 rhel = True
 
+        if self.vm.arch == "aarch64" and self.rhel_ver.split('.')[0] == '8':
+            output = self.session.cmd_output(
+                "rpm -qf /etc/pki/product-default/419.pem")
+            if output.startswith("redhat-release"):
+                rhel = True
+
         if self.vm.arch == "ppc64le":
             output = self.session.cmd_output(
                 "rpm -qf /etc/pki/product-default/279.pem")


### PR DESCRIPTION
1. Add whitelist for RHEL8.6 arm image
2. Check product certificate for RHEL8.6 arm image
3. Get the arch info from flavor configure file
4. Add whitelist for RHEL9.0 image since the podman rpm is required by CCSP