### PR TITLE
Add whitelist for RHEL8.7 & RHEL9.1 images and Modify virt-what test case

### DIFF
--- a/data/alibaba/cmdline_params.lst
+++ b/data/alibaba/cmdline_params.lst
@@ -2,3 +2,4 @@ no_timer_check
 console=ttyS0,115200n8
 net.ifnames=0
 crashkernel=auto
+crash_kexec_post_notifiers=1

--- a/data/alibaba/journalctl.el8.lst
+++ b/data/alibaba/journalctl.el8.lst
@@ -23,6 +23,9 @@ failed to assign [mem size 0x
 : Failed to check link status
 KD_FONT_OP_GET failed while trying to get the font metadata
 nofail,
+Unit dbus-org.freedesktop.resolve1.service not found
+skipped because of a failed condition check
+skipped because all trigger condition checks failed
 #################### KNOWN ISSUES BELOW ####################
 kernel: GPT: Use GNU Parted to correct GPT errors.
 org.freedesktop.DBus.Error.AccessDenied: Failed to restore old fd limit: Operation not permitted

--- a/data/alibaba/journalctl.el9.lst
+++ b/data/alibaba/journalctl.el9.lst
@@ -22,6 +22,8 @@ failed to assign [io  size 0x
 failed to assign [mem size 0x
 : Failed to check link status
 KD_FONT_OP_GET failed while trying to get the font metadata
+skipped because of a failed condition check
+skipped because all trigger condition checks failed
 #################### KNOWN ISSUES BELOW ####################
 kernel: GPT: Use GNU Parted to correct GPT errors.
 org.freedesktop.DBus.Error.AccessDenied: Failed to restore old fd limit: Operation not permitted
@@ -33,3 +35,6 @@ util.py[WARNING]: Running module keys-to-console
 cloud-final.service: Failed with result 'exit-code'.
 Failed to start Execute cloud user/final scripts.
 kernel: unchecked MSR access error: WRMSR to 0x3a
+# BZ1956121
+dbus-:1.1-org.fedoraproject.SetroubleshootPrivileged@0.service: Failed with result 'signal'
+dbus-:1.1-org.fedoraproject.Setroubleshootd@0.service: Failed with result 'signal'

--- a/data/alibaba/rpm_va.el8.lst
+++ b/data/alibaba/rpm_va.el8.lst
@@ -83,5 +83,8 @@ SM5..UGT.  c /etc/cloud/cloud.cfg
 .......T.    /boot/efi/EFI/redhat/shim.efi
 .......T.    /boot/efi/EFI/redhat/shimaa64-redhat.efi
 .......T.    /boot/efi/EFI/redhat/shimaa64.efi
+.M.......  c /boot/grub2/grub.cfg
+S.5....T.    /usr/share/authselect/default/sssd/password-auth
+S.5....T.    /usr/share/authselect/default/sssd/system-auth
 #################### KNOWN ISSUES BELOW ####################
 S.5....T.    /usr/lib/systemd/system/cloud-init.service

--- a/data/alibaba/rpm_va.el9.lst
+++ b/data/alibaba/rpm_va.el9.lst
@@ -83,5 +83,9 @@ S.5....T.  c /etc/containers/registries.conf
 .......T.    /boot/efi/EFI/redhat/mmaa64.efi
 .......T.    /boot/efi/EFI/redhat/shimaa64-redhat.efi
 .......T.    /boot/efi/EFI/redhat/shimaa64.efi
+.M.......  c /boot/grub2/grub.cfg
+.M.......    /boot/grub2/fonts/unicode.pf2
+S.5....T.    /usr/share/authselect/default/sssd/password-auth
+S.5....T.    /usr/share/authselect/default/sssd/system-auth
 #################### KNOWN ISSUES BELOW ####################
 S.5....T.    /usr/lib/systemd/system/cloud-init.service

--- a/data/alibaba/vulnerabilities.el8.lst
+++ b/data/alibaba/vulnerabilities.el8.lst
@@ -31,3 +31,10 @@ spectre_v2:Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: conditiona
 spectre_v2:Mitigation: Retpolines, STIBP: disabled, RSB filling
 spectre_v2:Mitigation: Retpolines, IBPB: conditional, STIBP: conditional, RSB filling
 spectre_v2:Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: always-on, RSB filling
+mmio_stale_data:Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
+mmio_stale_data:Mitigation: Clear CPU buffers; SMT vulnerable
+retbleed:Vulnerable
+retbleed:Mitigation: IBRS
+retbleed:Mitigation: Enhanced IBRS
+spectre_v2:Mitigation: Enhanced IBRS, RSB filling, PBRSB-eIBRS: SW sequence
+spectre_v2:Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling, PBRSB-eIBRS: SW sequence

--- a/data/alibaba/vulnerabilities.el9.lst
+++ b/data/alibaba/vulnerabilities.el9.lst
@@ -32,3 +32,7 @@ spectre_v2:Mitigation: Retpolines, STIBP: disabled, RSB filling
 spectre_v2:Mitigation: Retpolines, IBPB: conditional, STIBP: conditional, RSB filling
 spectre_v2:Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: always-on, RSB filling
 spectre_v2:Mitigation: CSV2, BHB
+mmio_stale_data:Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
+mmio_stale_data:Mitigation: Clear CPU buffers; SMT vulnerable
+retbleed:Vulnerable
+retbleed:Mitigation: IBRS


### PR DESCRIPTION
1. Add whitelist for RHEL8.7 and RHEL9.1 images
2. Modify virt-what test case since the latest virt-what supports Alibaba Cloud Linux