### PR TITLE
Fix 3 test cases per changes in rebase 23.1.1

### DIFF
--- a/tests/openstack/test_functional_cloudinit.py
+++ b/tests/openstack/test_functional_cloudinit.py
@@ -1205,15 +1205,15 @@ mounts:
         :avocado: tags=tier2,cloudinit,test_cloudinit_check_ds_identify_found
         RHEL-188251 - CLOUDINIT-TC: check ds-identify path
         1. Create a VM 
-        2. Check /run/cloud-init/cloud-init-generator.log, there should be "ds-identify _RET=found"
+        2. Check /run/cloud-init/cloud-init-generator.log, there should be "ds-identify rc=0"
         """
         self.session.connect(timeout=self.ssh_wait_timeout)
         cmd = 'cat /run/cloud-init/cloud-init-generator.log'
         utils_lib.run_cmd(self,
                           cmd,
                           expect_ret=0,
-                          expect_kw='ds-identify _RET=found',
-                          msg='check if there is ds-identify _RET=found',
+                          expect_kw='ds-identify rc=0',
+                          msg='check if there is ds-identify rc=0',
                           is_get_console=False)
 
     def _reboot_inside_vm(self):


### PR DESCRIPTION
1. test_cloudinit_save_and_handle_customdata_cloudinit_config
    Skipped 3 modules in 23.1.1, so only run 3 modules.     
    There is log likes "Skipping modules 'yum-add-repo,disable-ec2-metadata,runcmd' because no applicable config is provided"
2. test_cloudinit_save_and_handle_userdata_cloudinit_config
    Same as above 1.
3. test_cloudinit_check_ds_identity_path
    Check "ds-identify rc=0" instead of "ds-identify _RET=found", as the log "ds-identify _RET=found" is deleted in 23.1.1