### PR TITLE
[azure] self is not required as cmd_output first arg

### DIFF
--- a/tests/azure/test_functional_cloudinit.py
+++ b/tests/azure/test_functional_cloudinit.py
@@ -1614,7 +1614,7 @@ ssh_pwauth: 1
         '''
         self.log.info("RHEL-196560 - CLOUDINIT-TC: Check the cloud-init default config file /etc/cloud/cloud.cfg is not changed")
         self.session.cmd_output("cat /etc/cloud/cloud.cfg")        
-        out = self.session.cmd_output(self, 'ls /ostree/ | grep -i bootc')
+        out = self.session.cmd_output('ls /ostree/ | grep -i bootc')
         if 'bootc' in out:
             self.assertNotIn("/etc/cloud/cloud.cfg", self.session.cmd_output("sudo rpm -V cloud-init | grep -v '.......T.'"),
                 "The /etc/cloud/cloud.cfg is changed")


### PR DESCRIPTION
The first arg of cmd_output should be the command to be run. test_cloudinit_check_default_config test failed with the following error.

```
06:11:12 INFO | Command 'az vm show -d --name "walaautop1268r9d1v2" --resource-group "walaautoeastus"' finished with 0 after 5.91968894005s 06:11:13 INFO | RHEL-196560 - CLOUDINIT-TC: Check the cloud-init default config file /etc/cloud/cloud.cfg is not changed 06:11:13 ERROR|
06:11:13 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado/core/test.py:839 06:11:13 ERROR| Traceback (most recent call last):
06:11:13 ERROR|   File "/home/ci-jenkins-csb-esxi/workspace/Azure-package-runtest-1268/avocado-cloud/tests/azure/test_functional_cloudinit.py", line 1617, in test_cloudinit_check_default_config
06:11:13 ERROR|     out = self.session.cmd_output(self, 'ls /ostree/ | grep -i bootc')
06:11:13 ERROR|   File "/home/ci-jenkins-csb-esxi/workspace/Azure-package-runtest-1268/avocado-cloud/avocado_cloud/app/guest.py", line 29, in cmd_output
06:11:13 ERROR|     output = self.session.cmd_output(cmd, timeout).rstrip('\n')
06:11:13 ERROR|   File "/usr/lib/python2.7/site-packages/aexpect/client.py", line 1127, in cmd_output
06:11:13 ERROR|     self.read_nonblocking(0, timeout)
06:11:13 ERROR|   File "/usr/lib/python2.7/site-packages/aexpect/client.py", line 749, in read_nonblocking
06:11:13 ERROR|     end_time = time.time() + timeout
06:11:13 ERROR| TypeError: unsupported operand type(s) for +: 'float' and 'str'
```

The self in 1st arg was passed as the command, and the command in the 2nd arg was passed as timeout.